### PR TITLE
Jupyter notebook ipynb files additional kMDItemContentType "org.jupyter.ipynb"

### DIFF
--- a/QLPlugin/Info.plist
+++ b/QLPlugin/Info.plist
@@ -47,6 +47,7 @@
 
 				<!-- Jupyter Notebook -->
 				<string>dyn.ah62d4rv4ge80w6d3r3va</string> <!-- .ipynb -->
+				<string>org.jupyter.ipynb</string> <!-- .ipynb -->
 
 				<!-- Markdown -->
 				<string>com.unknown.md</string> <!-- .md (used by TeXShop) -->


### PR DESCRIPTION
add an additional id `org.jupyter.ipynb` for jupyter notebook files. All the `.ipynb` files on my Sequoia system come back with this id when I ask for the `kMDItemContentType`

```shell
mdls -name kMDItemContentType myfile.ipynb
```
 
I now managed to figure out the build process and have built with this patch and works fine on my mac.