### PR TITLE
Add content type `public.jupyter-notebook` for `.ipynb` files

### DIFF
--- a/QLPlugin/Info.plist
+++ b/QLPlugin/Info.plist
@@ -48,6 +48,7 @@
 				<!-- Jupyter Notebook -->
 				<string>dyn.ah62d4rv4ge80w6d3r3va</string> <!-- .ipynb -->
 				<string>org.jupyter.ipynb</string> <!-- .ipynb -->
+				<string>public.jupyter-notebook</string> <!-- .ipynb -->
 
 				<!-- Markdown -->
 				<string>com.unknown.md</string> <!-- .md (used by TeXShop) -->


### PR DESCRIPTION
This fixes an issue for me where no preview was being shown for `.ipynb` files on my system, macOS Sequoia 15.7.3 (24G419).

The apparent reason was that QuickLook identified `.ipynb` files as content type `public.jupyter-notebook`. I was able to determine this via the following steps:

* To get around [Private Logging Shenanigans](https://steipete.me/posts/2025/logging-privacy-shenanigans), in `/Library/Preferences/Logging/Subsystems`, create files `com.apple.quicklook.plist` and `com.apple.QuickLookDaemon.plist` containing

  ```
  <?xml version="1.0" encoding="UTF-8"?>
  <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
  <plist version="1.0">
  <dict>
      <key>DEFAULT-OPTIONS</key>
      <dict>
          <key>Enable-Private-Data</key>
          <true/>
      </dict>
  </dict>
  </plist>
  ```

* Run `log stream --predicate 'subsystem == "com.apple.QuickLookDaemon" OR subsystem == "com.apple.quicklook"' --level debug | tee quicklook.log`

* In a separate terminal window, run `qlmanage -p Untitled.ipynb`, where `Untitled.ipynb` is some Jupyter notebook file in my homefolder

* Inspect the generated `quicklook.log` file to show a message `Did not find any extension matching content type: public.jupyter-notebook` (among a lot of noise)

It is interesting that this content type does not match the content type reported by `mdls -name kMDItemContentType Untitled.ipynb` which reports `org.jupyter.ipynb`. I really have no idea how macOS determines the content type, but what's in the log seems to be the actual truth.

I've compiled and tested this locally, and adding the content type to the `Info.plist` fixes the issue for me, and now previews `.ipynb` files correctly.
