### PR TITLE
Improve front matter regex to reduce false positives on markdown sections

### DIFF
--- a/HTMLConverter/htmlconverter.go
+++ b/HTMLConverter/htmlconverter.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Regex for YAML front matter in a Markdown document
-var markdownFrontMatterRegex = regexp.MustCompile(`^---\n[\s\S]*?\n---\n`)
+var markdownFrontMatterRegex = regexp.MustCompile(`^---\n[^\n]*:[^\n]*\n[\s\S]*?\n---\n`)
 
 // Enable syntax highlighting in Markdown
 var markdownParser = goldmark.New(

--- a/HTMLConverter/htmlconverter_test.go
+++ b/HTMLConverter/htmlconverter_test.go
@@ -59,6 +59,54 @@ Text`
 	assert.Equal(t, expected, minifyHTML(actual))
 }
 
+func TestConvertMarkdownToHTMLWithFrontMatterAndBlankLines(t *testing.T) {
+	// YAML front matter containing blank lines should still be stripped
+	source := `---
+title: My Document
+
+description: A document
+---
+
+# Heading
+
+Text`
+	expected := "<h1>Heading</h1><p>Text</p>"
+	actual := convertToGoString(convertMarkdownToHTML(convertToCString(source)))
+	assert.Equal(t, expected, minifyHTML(actual))
+}
+
+func TestConvertMarkdownToHTMLWithThematicBreakNotStripped(t *testing.T) {
+	// A --- thematic break at the top followed by a blank line should NOT be treated as front matter
+	source := `---
+
+## My Section
+
+Some content
+
+---
+
+## Another Section
+
+More content`
+	actual := convertToGoString(convertMarkdownToHTML(convertToCString(source)))
+	assert.True(t, strings.Contains(actual, "My Section"), "first section heading should be present")
+	assert.True(t, strings.Contains(actual, "Some content"), "first section content should be present")
+	assert.True(t, strings.Contains(actual, "Another Section"), "second section heading should be present")
+}
+
+func TestConvertMarkdownToHTMLWithHeadingAfterThematicBreakNotStripped(t *testing.T) {
+	// A --- thematic break immediately followed by a heading (no colon) should NOT be treated as front matter
+	source := `---
+## My Section
+
+Content
+
+---`
+	actual := convertToGoString(convertMarkdownToHTML(convertToCString(source)))
+	assert.True(t, strings.Contains(actual, "My Section"), "section heading should be present")
+	assert.True(t, strings.Contains(actual, "Content"), "section content should be present")
+}
+
 func TestConvertMarkdownToHTMLWithSyntaxHighlighting(t *testing.T) {
 	source := "# Heading\n\nText\n\n```js\nconst print = (text) => console.log(text);\nprint(\"Hello world\");\n```" // nolint:lll
 	actual := convertToGoString(convertMarkdownToHTML(convertToCString(source)))


### PR DESCRIPTION
Related to Issue #79

## Problem

The YAML front matter regex was too permissive:

```regex
^---\n[\s\S]*?\n---\n
```

The pattern `[\s\S]*?` matches any content, including blank lines.
If a markdown file uses a thematic break (`---`) and contains another `---` anywhere later in the document, the regex incorrectly treats everything inbetween as YAML front matter.
This causes entire sections to be stripped from the QuickLook preview.

##  Approach

This is an iterative improvement, not a complete fix.
(Reliably distinguishing YAML front matter from arbitrary markdown content using a regex is not possible - any heuristic will have edge cases.)

This change adds a constraint:
the first line after `---` must contain a colon, which is typical for YAML key-value pairs (e.g. `title: Foo`, `date: 2026-04-01`), but uncommon in markdown headings or blank lines. The rest of the regex is unchanged.

```regex
^---\n[^\n]*:[^\n]*\n[\s\S]*?\n---\n
```

This reduces false positives in markdown files containing multiple thematic breaks, while preserving existing behaviour for valid YAML front matter.

## Known limitations

A thematic break immediately followed by a line containing a colon (e.g. **Note:...**) will be still incorrectly treated as front matter.

## Tests

Added test cases covering:
- thematic break followed by a blank line and sections (fixed)
- thematic break followed by a heading without a colon (fixed)
- YAML front matter with blank lines (existing behavior preserved)