### PR TITLE
add toml and ttml preview support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Xcode
 project.xcworkspace/
 xcuserdata/
+build/
+.DS_Store
 
 # `go build` output
 HTMLConverter/htmlconverter*.a

--- a/AppStore/Listing/Description.txt
+++ b/AppStore/Listing/Description.txt
@@ -8,7 +8,7 @@ Features:
 • Full compatibility with Dark Mode
 
 Supported file types:
-• Source code (.cpp, .js, .json, .py, .swift, .yml and many more)
+• Source code (.cpp, .js, .json, .py, .swift, .toml, .ttml, .yml and many more)
 • Markdown (.md, .markdown, .mdown, .mkdn, .mkd, .Rmd, .qmd)
 • Archive (.tar, .tar.gz, .zip)
 • Jupyter Notebook (.ipynb)

--- a/Glance.xcodeproj/project.pbxproj
+++ b/Glance.xcodeproj/project.pbxproj
@@ -12,6 +12,9 @@
 		10779BC42621502C008A903C /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 10779BC32621502C008A903C /* ZIPFoundation */; };
 		10779BEB26217F25008A903C /* SWCompression in Frameworks */ = {isa = PBXBuildFile; productRef = 10779BEA26217F25008A903C /* SWCompression */; };
 		10779C50262198EA008A903C /* htmlconverter.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E42B61D245857D9008D7116 /* htmlconverter.a */; };
+		A19F4D4226218B2B008A903C /* PreviewSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A19F4D4526218B2B008A903C /* PreviewSupport.swift */; };
+		A19F4D4326218B2B008A903C /* PreviewSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A19F4D4526218B2B008A903C /* PreviewSupport.swift */; };
+		A19F4D4426218B2B008A903C /* PreviewSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A19F4D4626218B2B008A903C /* PreviewSupportTests.swift */; };
 		7E022BE52452181F000EFCD3 /* WebPreviewVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E022BE32452181F000EFCD3 /* WebPreviewVC.swift */; };
 		7E022BE62452181F000EFCD3 /* WebPreviewVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7E022BE42452181F000EFCD3 /* WebPreviewVC.xib */; };
 		7E022BED245253B3000EFCD3 /* OutlinePreviewVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E022BEB245253B3000EFCD3 /* OutlinePreviewVC.swift */; };
@@ -168,6 +171,8 @@
 		103654F32F72623D006F2538 /* SevenZipPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SevenZipPreview.swift; sourceTree = "<group>"; };
 		10779C0D26218B2B008A903C /* GlanceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GlanceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		10779C1126218B2B008A903C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A19F4D4526218B2B008A903C /* PreviewSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewSupport.swift; sourceTree = "<group>"; };
+		A19F4D4626218B2B008A903C /* PreviewSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewSupportTests.swift; sourceTree = "<group>"; };
 		7E022BE32452181F000EFCD3 /* WebPreviewVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPreviewVC.swift; sourceTree = "<group>"; };
 		7E022BE42452181F000EFCD3 /* WebPreviewVC.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = WebPreviewVC.xib; sourceTree = "<group>"; };
 		7E022BEB245253B3000EFCD3 /* OutlinePreviewVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutlinePreviewVC.swift; sourceTree = "<group>"; };
@@ -316,6 +321,7 @@
 		10779C0E26218B2B008A903C /* GlanceTests */ = {
 			isa = PBXGroup;
 			children = (
+				A19F4D4626218B2B008A903C /* PreviewSupportTests.swift */,
 				10779C1126218B2B008A903C /* Info.plist */,
 			);
 			path = GlanceTests;
@@ -371,6 +377,7 @@
 			isa = PBXGroup;
 			children = (
 				7EE10F82244F6774007214D8 /* Log.swift */,
+				A19F4D4526218B2B008A903C /* PreviewSupport.swift */,
 				7E21C88C2438CAA500818EB2 /* Stats.swift */,
 			);
 			path = Utils;
@@ -842,6 +849,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A19F4D4426218B2B008A903C /* PreviewSupportTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -855,6 +863,7 @@
 				7EB7491924228549007265A4 /* JupyterPreview.swift in Sources */,
 				7E1B16922455D93E00E2B84D /* HTMLRenderer.swift in Sources */,
 				7EE10F84244F679B007214D8 /* Log.swift in Sources */,
+				A19F4D4226218B2B008A903C /* PreviewSupport.swift in Sources */,
 				7E21C88E24390BE400818EB2 /* Stats.swift in Sources */,
 				7E1DC51F240E6CE300D0A061 /* PreviewVC.swift in Sources */,
 				7E45F899244DA45500BFB869 /* FileTree.swift in Sources */,
@@ -885,6 +894,7 @@
 				7EE10F85244F696F007214D8 /* Log.swift in Sources */,
 				7E458AF52439481F0091BD0F /* Menu.swift in Sources */,
 				7E21C88D2438CAA500818EB2 /* Stats.swift in Sources */,
+				A19F4D4326218B2B008A903C /* PreviewSupport.swift in Sources */,
 				7ECC8CF2240CB4CC000D6970 /* AppDelegate.swift in Sources */,
 				7E458AF22439474E0091BD0F /* NSMenuItem.swift in Sources */,
 				7ED140662450C671007A7C70 /* SupportedFilesWC.swift in Sources */,
@@ -923,9 +933,14 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(SRCROOT)/**",
+					"$(PROJECT_DIR)/HTMLConverter",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.chamburr.Glance.GlanceTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/**";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Glance.app/Contents/MacOS/Glance";
 			};
@@ -946,9 +961,14 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(SRCROOT)/**",
+					"$(PROJECT_DIR)/HTMLConverter",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.chamburr.Glance.GlanceTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/**";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Glance.app/Contents/MacOS/Glance";
 			};

--- a/Glance.xcodeproj/project.pbxproj
+++ b/Glance.xcodeproj/project.pbxproj
@@ -933,14 +933,9 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				LIBRARY_SEARCH_PATHS = (
-					"$(SRCROOT)/**",
-					"$(PROJECT_DIR)/HTMLConverter",
-				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.chamburr.Glance.GlanceTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/**";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Glance.app/Contents/MacOS/Glance";
 			};
@@ -961,14 +956,9 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				LIBRARY_SEARCH_PATHS = (
-					"$(SRCROOT)/**",
-					"$(PROJECT_DIR)/HTMLConverter",
-				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.chamburr.Glance.GlanceTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/**";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Glance.app/Contents/MacOS/Glance";
 			};

--- a/Glance/Shared/Utils/PreviewSupport.swift
+++ b/Glance/Shared/Utils/PreviewSupport.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+enum PreviewFileType: Equatable {
+	case code
+	case jupyter
+	case markdown
+	case sevenZip
+	case tar
+	case tsv
+	case unsupported
+	case zip
+}
+
+enum PreviewSupport {
+	private static let dotfileLexers = [
+		// Files with syntax supported by Chroma
+		".bashrc": ".bashrc",
+		".vimrc": ".vimrc",
+		".zprofile": "zsh",
+		".zshrc": ".zshrc",
+		"dockerfile": "Dockerfile",
+		"gemfile": "Gemfile",
+		"gnumakefile": "Makefile",
+		"makefile": "Makefile",
+		"pkgbuild": "PKGBUILD",
+		"rakefile": "Rakefile",
+
+		// Files for which a different, similar syntax is used
+		".dockerignore": "bash",
+		".editorconfig": "ini",
+		".gitattributes": "bash",
+		".gitconfig": "ini",
+		".gitignore": "bash",
+		".npmignore": "bash",
+		".zsh_history": "txt",
+	]
+
+	private static let fileExtensionLexers = [
+		// Files with syntax supported by Chroma
+		"alfredappearance": "json",
+		"mobileconfig": "xml",
+		"cjs": "js",
+		"cls": "tex",
+		"csproj": "xml",
+		"entitlements": "xml",
+		"hbs": "handlebars",
+		"iml": "xml",
+		"mjs": "js",
+		"plist": "xml",
+		"props": "xml",
+		"resolved": "json",
+		"scpt": "applescript",
+		"scptd": "applescript",
+		"spf": "xml",
+		"spTheme": "xml",
+		"storyboard": "xml",
+		"stringsdict": "xml",
+		"sty": "tex",
+		"targets": "xml",
+		"webmanifest": "json",
+		"xcscheme": "xml",
+		"xib": "xml",
+		"xmp": "xml",
+
+		// Files for which a different, similar syntax is used
+		"ass": "txt",
+		"liquid": "twig",
+		"lrc": "txt",
+		"modulemap": "hcl",
+		"nfo": "txt",
+		"njk": "twig",
+		"pbxproj": "txt",
+		"sln": "txt",
+		"srt": "txt",
+		"strings": "c",
+		"ttml": "xml",
+		"vtt": "txt",
+	]
+
+	static func getCodeLexer(fileURL: URL) -> String {
+		if fileURL.pathExtension.isEmpty {
+			return dotfileLexers[fileURL.lastPathComponent.lowercased(), default: "autodetect"]
+		} else if fileURL.pathExtension.lowercased() == "dist" {
+			return getCodeLexer(fileURL: fileURL.deletingPathExtension())
+		} else {
+			return fileExtensionLexers[
+				fileURL.pathExtension.lowercased(),
+				default: fileURL.pathExtension
+			]
+		}
+	}
+
+	static func getPreviewFileType(fileURL: URL) -> PreviewFileType {
+		switch fileURL.pathExtension.lowercased() {
+			case "gz":
+				return fileURL.path.hasSuffix(".tar.gz") ? .tar : .unsupported
+			case "md", "markdown", "mdown", "mkdn", "mkd", "rmd", "qmd":
+				return .markdown
+			case "ipynb":
+				return .jupyter
+			case "tar", "tgz":
+				return .tar
+			case "tab", "tsv":
+				return .tsv
+			case "7z":
+				return .sevenZip
+			case "ear", "jar", "war", "zip":
+				return .zip
+			default:
+				return .code
+		}
+	}
+}

--- a/Glance/Shared/Utils/PreviewSupport.swift
+++ b/Glance/Shared/Utils/PreviewSupport.swift
@@ -91,9 +91,11 @@ enum PreviewSupport {
 	}
 
 	static func getPreviewFileType(fileURL: URL) -> PreviewFileType {
+		let normalizedPath = fileURL.path.lowercased()
+
 		switch fileURL.pathExtension.lowercased() {
 			case "gz":
-				return fileURL.path.hasSuffix(".tar.gz") ? .tar : .unsupported
+				return normalizedPath.hasSuffix(".tar.gz") ? .tar : .unsupported
 			case "md", "markdown", "mdown", "mkdn", "mkd", "rmd", "qmd":
 				return .markdown
 			case "ipynb":

--- a/Glance/SupportedFilesWC.xib
+++ b/Glance/SupportedFilesWC.xib
@@ -42,7 +42,7 @@
                                             </attributes>
                                         </fragment>
                                         <fragment>
-                                            <string key="content"> .cpp, .js, .json, .py, .swift, .yml and many more
+                                            <string key="content"> .cpp, .js, .json, .py, .swift, .toml, .ttml, .yml and many more
 
 </string>
                                             <attributes>

--- a/GlanceTests/PreviewSupportTests.swift
+++ b/GlanceTests/PreviewSupportTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import Glance
+
+final class PreviewSupportTests: XCTestCase {
+	func testPreviewTypeUsesCodePreviewForToml() {
+		let fileURL = URL(fileURLWithPath: "/tmp/example.toml")
+
+		XCTAssertEqual(PreviewSupport.getPreviewFileType(fileURL: fileURL), .code)
+	}
+
+	func testPreviewTypeUsesCodePreviewForTtml() {
+		let fileURL = URL(fileURLWithPath: "/tmp/example.ttml")
+
+		XCTAssertEqual(PreviewSupport.getPreviewFileType(fileURL: fileURL), .code)
+	}
+
+	func testCodeLexerUsesTomlLexerForTomlFiles() {
+		let fileURL = URL(fileURLWithPath: "/tmp/example.toml")
+
+		XCTAssertEqual(PreviewSupport.getCodeLexer(fileURL: fileURL), "toml")
+	}
+
+	func testCodeLexerUsesXmlLexerForTtmlFiles() {
+		let fileURL = URL(fileURLWithPath: "/tmp/example.ttml")
+
+		XCTAssertEqual(PreviewSupport.getCodeLexer(fileURL: fileURL), "xml")
+	}
+
+	func testCodeLexerKeepsExistingSubtitleMappings() {
+		let fileURL = URL(fileURLWithPath: "/tmp/example.srt")
+
+		XCTAssertEqual(PreviewSupport.getCodeLexer(fileURL: fileURL), "txt")
+	}
+}

--- a/GlanceTests/PreviewSupportTests.swift
+++ b/GlanceTests/PreviewSupportTests.swift
@@ -2,16 +2,28 @@ import XCTest
 @testable import Glance
 
 final class PreviewSupportTests: XCTestCase {
-	func testPreviewTypeUsesCodePreviewForToml() {
-		let fileURL = URL(fileURLWithPath: "/tmp/example.toml")
+	func testPreviewTypeUsesTarPreviewForUppercaseTarGzFiles() {
+		let fileURL = URL(fileURLWithPath: "/tmp/example.TAR.GZ")
 
-		XCTAssertEqual(PreviewSupport.getPreviewFileType(fileURL: fileURL), .code)
+		XCTAssertEqual(PreviewSupport.getPreviewFileType(fileURL: fileURL), .tar)
 	}
 
-	func testPreviewTypeUsesCodePreviewForTtml() {
-		let fileURL = URL(fileURLWithPath: "/tmp/example.ttml")
+	func testPreviewTypeUsesUnsupportedPreviewForPlainGzFiles() {
+		let fileURL = URL(fileURLWithPath: "/tmp/example.gz")
 
-		XCTAssertEqual(PreviewSupport.getPreviewFileType(fileURL: fileURL), .code)
+		XCTAssertEqual(PreviewSupport.getPreviewFileType(fileURL: fileURL), .unsupported)
+	}
+
+	func testPreviewTypeUsesTsvPreviewForTsvFiles() {
+		let fileURL = URL(fileURLWithPath: "/tmp/example.tsv")
+
+		XCTAssertEqual(PreviewSupport.getPreviewFileType(fileURL: fileURL), .tsv)
+	}
+
+	func testPreviewTypeUsesZipPreviewForZipFiles() {
+		let fileURL = URL(fileURLWithPath: "/tmp/example.zip")
+
+		XCTAssertEqual(PreviewSupport.getPreviewFileType(fileURL: fileURL), .zip)
 	}
 
 	func testCodeLexerUsesTomlLexerForTomlFiles() {

--- a/QLPlugin/Info.plist
+++ b/QLPlugin/Info.plist
@@ -163,6 +163,7 @@
 				<string>dyn.ah62d4rv4ge81k2pwq7w1k62</string> <!-- .targets -->
 				<string>dyn.ah62d4rv4ge81k55d</string> <!-- .toc (LaTeX) -->
 				<string>dyn.ah62d4rv4ge81k55rru</string> <!-- .toml -->
+				<string>dyn.ah62d4rv4ge81k7drru</string> <!-- .ttml -->
 				<string>dyn.ah62d4rv4ge81k652</string> <!-- .tsx -->
 				<string>dyn.ah62d4rv4ge81k75mq6</string> <!-- .twig -->
 				<string>dyn.ah62d4rv4ge81k7dq</string> <!-- .ttl (Turtle) -->
@@ -252,6 +253,7 @@
 				<string>public.shell-script</string> <!-- .sh -->
 				<string>public.source-code</string>
 				<string>public.swift-source</string> <!-- .swift -->
+				<string>public.toml</string> <!-- .toml -->
 				<string>public.tcsh-script</string> <!-- .tcsh -->
 				<string>public.tex</string> <!-- .tex -->
 				<string>public.text</string>

--- a/QLPlugin/Views/PreviewVCFactory.swift
+++ b/QLPlugin/Views/PreviewVCFactory.swift
@@ -4,24 +4,23 @@ import Foundation
 /// May return `nil` if the file is not supported.
 class PreviewVCFactory {
 	static func getPreviewInitializer(fileURL: URL) -> Preview.Type? {
-		switch fileURL.pathExtension.lowercased() {
-			case "gz":
-				// `gzip` is only supported for tarballs
-				return fileURL.path.hasSuffix(".tar.gz") ? TARPreview.self : nil
-			case "md", "markdown", "mdown", "mkdn", "mkd", "rmd", "qmd":
+		switch PreviewSupport.getPreviewFileType(fileURL: fileURL) {
+			case .markdown:
 				return MarkdownPreview.self
-			case "ipynb":
+			case .jupyter:
 				return JupyterPreview.self
-			case "tar", "tgz":
+			case .tar:
 				return TARPreview.self
-			case "tab", "tsv":
+			case .tsv:
 				return TSVPreview.self
-			case "7z":
+			case .sevenZip:
 				return SevenZipPreview.self
-			case "ear", "jar", "war", "zip":
+			case .zip:
 				return ZIPPreview.self
-			default:
+			case .code:
 				return CodePreview.self
+			case .unsupported:
+				return nil
 		}
 	}
 }

--- a/QLPlugin/Views/Previews/CodePreview.swift
+++ b/QLPlugin/Views/Previews/CodePreview.swift
@@ -1,70 +1,6 @@
 import Foundation
 import os.log
 
-let dotfileLexers = [
-	// Files with syntax supported by Chroma
-	".bashrc": ".bashrc",
-	".vimrc": ".vimrc",
-	".zprofile": "zsh",
-	".zshrc": ".zshrc",
-	"dockerfile": "Dockerfile",
-	"gemfile": "Gemfile",
-	"gnumakefile": "Makefile",
-	"makefile": "Makefile",
-	"pkgbuild": "PKGBUILD",
-	"rakefile": "Rakefile",
-
-	// Files for which a different, similar syntax is used
-	".dockerignore": "bash",
-	".editorconfig": "ini",
-	".gitattributes": "bash",
-	".gitconfig": "ini",
-	".gitignore": "bash",
-	".npmignore": "bash",
-	".zsh_history": "txt",
-]
-
-let fileExtensionLexers = [
-	// Files with syntax supported by Chroma
-	"alfredappearance": "json",
-	"mobileconfig": "xml",
-	"cjs": "js",
-	"cls": "tex",
-	"csproj": "xml",
-	"entitlements": "xml",
-	"hbs": "handlebars",
-	"iml": "xml",
-	"mjs": "js",
-	"plist": "xml",
-	"props": "xml",
-	"resolved": "json",
-	"scpt": "applescript",
-	"scptd": "applescript",
-	"spf": "xml",
-	"spTheme": "xml",
-	"storyboard": "xml",
-	"stringsdict": "xml",
-	"sty": "tex",
-	"targets": "xml",
-	"webmanifest": "json",
-	"xcscheme": "xml",
-	"xib": "xml",
-	"xmp": "xml",
-
-	// Files for which a different, similar syntax is used
-	"ass": "txt",
-	"liquid": "twig",
-	"lrc": "txt",
-	"modulemap": "hcl",
-	"nfo": "txt",
-	"njk": "twig",
-	"pbxproj": "txt",
-	"sln": "txt",
-	"srt": "txt",
-	"strings": "c",
-	"vtt": "txt",
-]
-
 class CodePreview: Preview {
 	private let chromaStylesheetURL = Bundle.main.url(
 		forResource: "shared-chroma",
@@ -72,24 +8,6 @@ class CodePreview: Preview {
 	)
 
 	required init() {}
-
-	/// Returns the name of the Chroma lexer to use for the file. This is determined based on the
-	/// file name/extension.
-	private func getLexer(fileURL: URL) -> String {
-		if fileURL.pathExtension.isEmpty {
-			// Dotfile
-			return dotfileLexers[fileURL.lastPathComponent.lowercased(), default: "autodetect"]
-		} else if fileURL.pathExtension.lowercased() == "dist" {
-			// .dist file
-			return getLexer(fileURL: fileURL.deletingPathExtension())
-		} else {
-			// File with extension
-			return fileExtensionLexers[
-				fileURL.pathExtension.lowercased(),
-				default: fileURL.pathExtension
-			]
-		}
-	}
 
 	func getSource(file: File) throws -> String {
 		try file.read()
@@ -109,7 +27,7 @@ class CodePreview: Preview {
 			throw error
 		}
 
-		let lexer = getLexer(fileURL: file.url)
+		let lexer = PreviewSupport.getCodeLexer(fileURL: file.url)
 		do {
 			return try HTMLRenderer.renderCode(source, lexer: lexer)
 		} catch {

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Alternatively, you can install Glance directly. The installation is slightly com
 
 ## Supported file types
 
-- **Source code** (with [Chroma](https://github.com/alecthomas/chroma) syntax highlighting): `.cpp`, `.js`, `.json`, `.py`, `.swift`, `.yml` and many more
+- **Source code** (with [Chroma](https://github.com/alecthomas/chroma) syntax highlighting): `.cpp`, `.js`, `.json`, `.py`, `.swift`, `.toml`, `.ttml`, `.yml` and many more
 
   <p><img src="./AppStore/Assets/Screenshots/ScreenshotSourceCode.png" alt="" width="600"></p>
 


### PR DESCRIPTION
Adds support for .toml and .ttml previews in Glance. Updates Quick Look content-type registration, maps TTML to XML highlighting, factors preview routing and lexer selection into a shared utility, adds unit tests for the new behavior, and updates supported-file documentation.