### PR TITLE
Add .3mf file support

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -156,6 +156,7 @@ identifier_name:
   excluded:
     - "x"
     - "y"
+    - "z"
     - "a"
     - "b"
     - "x1"

--- a/Glance.xcodeproj/project.pbxproj
+++ b/Glance.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		10A3F0012F80000000000006 /* SCNVector3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10A3F0002F80000000000006 /* SCNVector3.swift */; };
+		10A3F0012F80000000000005 /* ModelCamera.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10A3F0002F80000000000005 /* ModelCamera.swift */; };
+		10A3F0012F80000000000001 /* ThreeMFModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10A3F0002F80000000000001 /* ThreeMFModel.swift */; };
+		10A3F0012F80000000000002 /* ThreeMFParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10A3F0002F80000000000002 /* ThreeMFParser.swift */; };
+		10A3F0012F80000000000003 /* ModelPreviewVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10A3F0002F80000000000003 /* ModelPreviewVC.swift */; };
+		10A3F0012F80000000000004 /* ThreeMFPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10A3F0002F80000000000004 /* ThreeMFPreview.swift */; };
 		102D56C526206A36000B5C0E /* MainVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 102D56C426206A36000B5C0E /* MainVC.swift */; };
 		103654F42F726241006F2538 /* SevenZipPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 103654F32F72623D006F2538 /* SevenZipPreview.swift */; };
 		10779BC42621502C008A903C /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 10779BC32621502C008A903C /* ZIPFoundation */; };
@@ -164,6 +170,12 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		10A3F0002F80000000000006 /* SCNVector3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SCNVector3.swift; sourceTree = "<group>"; };
+		10A3F0002F80000000000005 /* ModelCamera.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelCamera.swift; sourceTree = "<group>"; };
+		10A3F0002F80000000000001 /* ThreeMFModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeMFModel.swift; sourceTree = "<group>"; };
+		10A3F0002F80000000000002 /* ThreeMFParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeMFParser.swift; sourceTree = "<group>"; };
+		10A3F0002F80000000000003 /* ModelPreviewVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelPreviewVC.swift; sourceTree = "<group>"; };
+		10A3F0002F80000000000004 /* ThreeMFPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeMFPreview.swift; sourceTree = "<group>"; };
 		102D56C426206A36000B5C0E /* MainVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainVC.swift; sourceTree = "<group>"; };
 		103654F32F72623D006F2538 /* SevenZipPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SevenZipPreview.swift; sourceTree = "<group>"; };
 		10779C0D26218B2B008A903C /* GlanceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GlanceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -327,6 +339,7 @@
 				7EAC01EB240D220B009505D0 /* File.swift */,
 				7E45F898244DA45500BFB869 /* FileTree.swift */,
 				7E1B16912455D93E00E2B84D /* HTMLRenderer.swift */,
+				10A3F0022F80000000000001 /* ThreeMF */,
 				7E9F0D7924168870007F1008 /* WebAsset */,
 			);
 			path = Utils;
@@ -357,6 +370,7 @@
 			isa = PBXGroup;
 			children = (
 				103654F32F72623D006F2538 /* SevenZipPreview.swift */,
+				10A3F0002F80000000000004 /* ThreeMFPreview.swift */,
 				7E1DC529240E6FDE00D0A061 /* CodePreview.swift */,
 				7EB7491824228549007265A4 /* JupyterPreview.swift */,
 				7E1DC520240E6D8000D0A061 /* MarkdownPreview.swift */,
@@ -413,6 +427,8 @@
 		7E616BB324499A380043F7AB /* PreviewVCs */ = {
 			isa = PBXGroup;
 			children = (
+				10A3F0002F80000000000005 /* ModelCamera.swift */,
+				10A3F0002F80000000000003 /* ModelPreviewVC.swift */,
 				7E022BEC245253B3000EFCD3 /* OutlinePreviewVC.xib */,
 				7E022BEB245253B3000EFCD3 /* OutlinePreviewVC.swift */,
 				7E08A50E2454372200B7FF53 /* TablePreviewVC.xib */,
@@ -446,6 +462,15 @@
 				102D56C426206A36000B5C0E /* MainVC.swift */,
 			);
 			path = QLPlugin;
+			sourceTree = "<group>";
+		};
+		10A3F0022F80000000000001 /* ThreeMF */ = {
+			isa = PBXGroup;
+			children = (
+				10A3F0002F80000000000001 /* ThreeMFModel.swift */,
+				10A3F0002F80000000000002 /* ThreeMFParser.swift */,
+			);
+			path = ThreeMF;
 			sourceTree = "<group>";
 		};
 		7E9F0D7924168870007F1008 /* WebAsset */ = {
@@ -557,6 +582,7 @@
 		7EB36486244B65D900D7F96F /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				10A3F0002F80000000000006 /* SCNVector3.swift */,
 				7EB36487244B65D900D7F96F /* String.swift */,
 			);
 			path = Extensions;
@@ -850,6 +876,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7EB36488244B65D900D7F96F /* String.swift in Sources */,
+				10A3F0012F80000000000006 /* SCNVector3.swift in Sources */,
 				7EAC01EC240D220B009505D0 /* File.swift in Sources */,
 				7E458AED2439176B0091BD0F /* Date.swift in Sources */,
 				7EB7491924228549007265A4 /* JupyterPreview.swift in Sources */,
@@ -871,6 +898,11 @@
 				7E9F0D7E24168870007F1008 /* Script.swift in Sources */,
 				7EB3648A244B665700D7F96F /* ZIPPreview.swift in Sources */,
 				103654F42F726241006F2538 /* SevenZipPreview.swift in Sources */,
+				10A3F0012F80000000000001 /* ThreeMFModel.swift in Sources */,
+				10A3F0012F80000000000002 /* ThreeMFParser.swift in Sources */,
+				10A3F0012F80000000000003 /* ModelPreviewVC.swift in Sources */,
+				10A3F0012F80000000000005 /* ModelCamera.swift in Sources */,
+				10A3F0012F80000000000004 /* ThreeMFPreview.swift in Sources */,
 				7E9F0D7D24168870007F1008 /* Stylesheet.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Glance/SupportedFilesWC.xib
+++ b/Glance/SupportedFilesWC.xib
@@ -127,6 +127,23 @@ Cg
                                                 <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
                                             </attributes>
                                         </fragment>
+                                        <fragment content="
+
+3D model">
+                                            <attributes>
+                                                <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                <font key="NSFont" size="13" name="HelveticaNeue-Bold"/>
+                                                <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                            </attributes>
+                                        </fragment>
+                                        <fragment content="
+.3mf">
+                                            <attributes>
+                                                <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                <font key="NSFont" size="13" name="HelveticaNeue"/>
+                                                <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                            </attributes>
+                                        </fragment>
                                     </attributedString>
                                     <color key="insertionPointColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                 </textView>

--- a/QLPlugin/Extensions/SCNVector3.swift
+++ b/QLPlugin/Extensions/SCNVector3.swift
@@ -1,0 +1,36 @@
+import Foundation
+import SceneKit
+
+extension SCNVector3 {
+	func dot(_ other: SCNVector3) -> CGFloat {
+		x * other.x + y * other.y + z * other.z
+	}
+
+	func cross(_ other: SCNVector3) -> SCNVector3 {
+		SCNVector3(
+			y * other.z - z * other.y,
+			z * other.x - x * other.z,
+			x * other.y - y * other.x
+		)
+	}
+
+	/// Returns the vector scaled to a length of one, or the unit vector along the z-axis if the
+	/// vector has no length.
+	func normalized() -> SCNVector3 {
+		let length = sqrt(x * x + y * y + z * z)
+		guard length > 0 else {
+			return SCNVector3(0, 0, 1)
+		}
+		return SCNVector3(x / length, y / length, z / length)
+	}
+
+	/// Applies a transform to the point. SceneKit stores the translation in the fourth row of a
+	/// matrix, so points are multiplied as row vectors.
+	func transformed(by matrix: SCNMatrix4) -> SCNVector3 {
+		SCNVector3(
+			x * matrix.m11 + y * matrix.m21 + z * matrix.m31 + matrix.m41,
+			x * matrix.m12 + y * matrix.m22 + z * matrix.m32 + matrix.m42,
+			x * matrix.m13 + y * matrix.m23 + z * matrix.m33 + matrix.m43
+		)
+	}
+}

--- a/QLPlugin/Info.plist
+++ b/QLPlugin/Info.plist
@@ -36,6 +36,9 @@
 					- public.xml (.xml)
 				-->
 
+				<!-- 3D model -->
+				<string>dyn.ah62d4rv4ge8xg5pg</string> <!-- .3mf -->
+
 				<!-- Archive -->
 				<string>org.7-zip.7-zip-archive</string> <!-- .7z -->
 				<string>com.sun.java-archive</string> <!-- .jar (Java) -->

--- a/QLPlugin/Utils/File.swift
+++ b/QLPlugin/Utils/File.swift
@@ -27,7 +27,9 @@ extension FileError: LocalizedError {
 
 /// Utility class for reading the content and metadata of the corresponding file.
 class File {
-	let archiveExtensions = ["7z", "tar", "tar.gz", "tgz", "zip"]
+	/// Extensions of container formats, whose content is much larger than the data that needs to be
+	/// read to generate a preview
+	let archiveExtensions = ["3mf", "7z", "tar", "tar.gz", "tgz", "zip"]
 	let fileManager = FileManager.default
 
 	var attributes: [FileAttributeKey: Any]
@@ -35,7 +37,7 @@ class File {
 	var path: String
 	var url: URL
 
-	var isArchive: Bool { archiveExtensions.contains(url.pathExtension) }
+	var isArchive: Bool { archiveExtensions.contains(url.pathExtension.lowercased()) }
 	var size: Int { attributes[.size] as? Int ?? 0 }
 
 	/// Looks for a file at the provided URL and saves its metadata as object properties.

--- a/QLPlugin/Utils/ThreeMF/ThreeMFModel.swift
+++ b/QLPlugin/Utils/ThreeMF/ThreeMFModel.swift
@@ -1,0 +1,487 @@
+import Cocoa
+import os.log
+import SceneKit
+
+/// Unit of measurement a 3MF model is expressed in.
+enum ThreeMFUnit: String {
+	case micron
+	case millimeter
+	case centimeter
+	case inch
+	case foot
+	case meter
+
+	/// Length of one unit in millimeters.
+	var millimeters: CGFloat {
+		switch self {
+			case .micron:
+				return 0.001
+			case .millimeter:
+				return 1
+			case .centimeter:
+				return 10
+			case .inch:
+				return 25.4
+			case .foot:
+				return 304.8
+			case .meter:
+				return 1000
+		}
+	}
+}
+
+/// Triangle mesh of a 3MF object. Triangles are stored as a flat list of indices into `vertices`.
+struct ThreeMFMesh {
+	var vertices = [SCNVector3]()
+	var triangles = [Int32]()
+
+	var triangleCount: Int {
+		triangles.count / 3
+	}
+}
+
+/// Reference from an object to another object, with the transform to apply to it.
+struct ThreeMFComponent {
+	let objectKey: String
+	let transform: SCNMatrix4
+}
+
+/// Object of a 3MF model. It either contains a mesh, or is an assembly of other objects.
+struct ThreeMFObject {
+	var mesh: ThreeMFMesh?
+	var components = [ThreeMFComponent]()
+	/// Property group the object's color is taken from (`pid` attribute)
+	var propertyGroupKey: String?
+	/// Index of the object's color within its property group (`pindex` attribute)
+	var propertyIndex: Int?
+}
+
+/// Object placed on the build platform, with the transform to apply to it.
+struct ThreeMFBuildItem {
+	let objectKey: String
+	let transform: SCNMatrix4
+}
+
+/// Contents of a 3MF file. Objects and property groups are keyed by `<part path>#<id>`, because IDs
+/// are only unique within the model part they are declared in (production extension).
+struct ThreeMFModel {
+	var unit = ThreeMFUnit.millimeter
+	var objects = [String: ThreeMFObject]()
+	var buildItems = [ThreeMFBuildItem]()
+	/// Colors declared by `<basematerials>` and `<colorgroup>` resources
+	var propertyGroups = [String: [NSColor]]()
+	var triangleCount = 0
+}
+
+/// Rendered 3MF model, together with the metadata shown next to the preview.
+struct ThreeMFScene {
+	let scene: SCNScene
+	/// Camera to position once the size of the view is known
+	let camera: ModelCamera
+	/// Size of the model's bounding box in millimeters
+	let dimensions: SCNVector3
+	let triangleCount: Int
+}
+
+/// Axis-aligned bounding box.
+private struct Bounds {
+	var min: SCNVector3
+	var max: SCNVector3
+
+	init(min: SCNVector3, max: SCNVector3) {
+		self.min = min
+		self.max = max
+	}
+
+	init?(vertices: [SCNVector3]) {
+		guard let first = vertices.first else {
+			return nil
+		}
+		min = first
+		max = first
+		for vertex in vertices.dropFirst() {
+			min.x = Swift.min(min.x, vertex.x)
+			min.y = Swift.min(min.y, vertex.y)
+			min.z = Swift.min(min.z, vertex.z)
+			max.x = Swift.max(max.x, vertex.x)
+			max.y = Swift.max(max.y, vertex.y)
+			max.z = Swift.max(max.z, vertex.z)
+		}
+	}
+
+	var center: SCNVector3 {
+		SCNVector3((min.x + max.x) / 2, (min.y + max.y) / 2, (min.z + max.z) / 2)
+	}
+
+	var size: SCNVector3 {
+		SCNVector3(max.x - min.x, max.y - min.y, max.z - min.z)
+	}
+
+	/// Whether the box can be measured and framed. Coordinates are checked as they are read, but
+	/// transforms compose multiplicatively up the tree, so a chain of individually harmless scales
+	/// still lands the box out of range. Checking for infinity is not enough here either: SceneKit
+	/// stores node positions as single precision floats.
+	var isRenderable: Bool {
+		[min.x, min.y, min.z, max.x, max.y, max.z].allSatisfy {
+			$0.isFinite && abs($0) <= CGFloat(ThreeMFLimits.maxCoordinate)
+		}
+	}
+
+	/// Radius of the sphere containing the bounding box.
+	var radius: CGFloat {
+		let size = self.size
+		return sqrt(size.x * size.x + size.y * size.y + size.z * size.z) / 2
+	}
+
+	func union(_ other: Bounds) -> Bounds {
+		Bounds(
+			min: SCNVector3(
+				Swift.min(min.x, other.min.x),
+				Swift.min(min.y, other.min.y),
+				Swift.min(min.z, other.min.z)
+			),
+			max: SCNVector3(
+				Swift.max(max.x, other.max.x),
+				Swift.max(max.y, other.max.y),
+				Swift.max(max.z, other.max.z)
+			)
+		)
+	}
+
+	var corners: [SCNVector3] {
+		var corners = [SCNVector3]()
+		for x in [min.x, max.x] {
+			for y in [min.y, max.y] {
+				for depth in [min.z, max.z] {
+					corners.append(SCNVector3(x, y, depth))
+				}
+			}
+		}
+		return corners
+	}
+
+	/// Returns the bounding box of this box's eight corners after applying the transform.
+	func transformed(by transform: SCNMatrix4) -> Bounds {
+		// The array is never empty, so the initializer cannot fail
+		Bounds(vertices: corners.map { $0.transformed(by: transform) })!
+	}
+}
+
+extension ThreeMFModel {
+	/// Color used for objects without a material
+	static let defaultColor = NSColor(calibratedRed: 0.65, green: 0.68, blue: 0.73, alpha: 1)
+
+	/// Builds a SceneKit scene containing all objects placed on the build platform.
+	func buildScene() throws -> ThreeMFScene {
+		var geometries = [String: SCNGeometry]()
+		var boundsCache = [String: Bounds?]()
+		var nodeCount = 0
+		var renderedTriangles = 0
+
+		// Objects of the build platform, in the model's own coordinate system
+		let contentNode = SCNNode()
+		var contentBounds: Bounds?
+
+		for item in buildItems {
+			guard let node = try makeNode(
+				objectKey: item.objectKey,
+				geometries: &geometries,
+				nodeCount: &nodeCount,
+				renderedTriangles: &renderedTriangles
+			) else {
+				continue
+			}
+			node.transform = item.transform
+			contentNode.addChildNode(node)
+
+			var hitCycle = false
+			let itemBounds = localBounds(
+				objectKey: item.objectKey,
+				cache: &boundsCache,
+				hitCycle: &hitCycle
+			)
+			if let bounds = itemBounds?.transformed(by: item.transform) {
+				contentBounds = contentBounds?.union(bounds) ?? bounds
+			}
+		}
+
+		// Every node that is kept holds geometry somewhere below it, so an empty platform means
+		// there is nothing to show (e.g. a file whose objects only reference each other)
+		guard !contentNode.childNodes.isEmpty else {
+			throw ThreeMFError.emptyModelError
+		}
+
+		// Rather than measuring and framing the model with values that overflowed, fall back to
+		// showing it from a default distance
+		if contentBounds?.isRenderable == false {
+			os_log("Ignoring 3MF bounding box that is out of range", log: Log.render, type: .error)
+			contentBounds = nil
+		}
+
+		// 3MF models are Z-up, SceneKit is Y-up
+		let rootNode = SCNNode()
+		rootNode.transform = SCNMatrix4MakeRotation(-.pi / 2, 1, 0, 0)
+		rootNode.addChildNode(contentNode)
+
+		let scene = SCNScene()
+		scene.rootNode.addChildNode(rootNode)
+		let camera = makeCamera(bounds: contentBounds)
+		scene.rootNode.addChildNode(camera.node)
+		addLights(to: scene)
+
+		let size = contentBounds?.size ?? SCNVector3Zero
+		let scale = unit.millimeters
+		return ThreeMFScene(
+			scene: scene,
+			camera: camera,
+			dimensions: SCNVector3(size.x * scale, size.y * scale, size.z * scale),
+			triangleCount: renderedTriangles
+		)
+	}
+
+	/// Builds the node for an object, recursing into its components. `visited` guards against
+	/// objects referencing each other in a cycle, which the 3MF specification forbids, and
+	/// `nodeCount` against objects that reference each other so often that the scene explodes even
+	/// though the file holds barely any geometry.
+	private func makeNode(
+		objectKey: String,
+		geometries: inout [String: SCNGeometry],
+		nodeCount: inout Int,
+		renderedTriangles: inout Int,
+		visited: Set<String> = [],
+		depth: Int = 0
+	) throws -> SCNNode? {
+		guard !visited.contains(objectKey), let object = objects[objectKey] else {
+			return nil
+		}
+		// A chain of objects each referencing a single other object stays well within `maxNodes`
+		// while recursing once per level, which would exhaust the stack
+		guard depth < ThreeMFLimits.maxObjectDepth else {
+			throw ThreeMFError.tooLargeError(
+				reason: "objects nested more than \(ThreeMFLimits.maxObjectDepth) levels deep"
+			)
+		}
+		var visited = visited
+		visited.insert(objectKey)
+
+		nodeCount += 1
+		guard nodeCount <= ThreeMFLimits.maxNodes else {
+			throw ThreeMFError
+				.tooLargeError(reason: "more than \(ThreeMFLimits.maxNodes) objects to place")
+		}
+
+		let node = SCNNode()
+
+		if let mesh = object.mesh, mesh.triangleCount > 0 {
+			if let geometry = geometries[objectKey] {
+				node.geometry = geometry
+			} else if let geometry = ThreeMFModel.makeGeometry(
+				mesh: mesh,
+				color: color(of: object)
+			) {
+				geometries[objectKey] = geometry
+				node.geometry = geometry
+			}
+			// Triangles the file declares but that couldn't be rendered (e.g. because they refer
+			// to vertices that don't exist) are not counted
+			renderedTriangles += node.geometry?.elements.first?.primitiveCount ?? 0
+		}
+
+		for component in object.components {
+			guard let childNode = try makeNode(
+				objectKey: component.objectKey,
+				geometries: &geometries,
+				nodeCount: &nodeCount,
+				renderedTriangles: &renderedTriangles,
+				visited: visited,
+				depth: depth + 1
+			) else {
+				continue
+			}
+			childNode.transform = component.transform
+			node.addChildNode(childNode)
+		}
+
+		return node.geometry == nil && node.childNodes.isEmpty ? nil : node
+	}
+
+	/// Bounding box of an object in its own coordinate system, including its components.
+	/// `hitCycle` reports whether the traversal was cut short by the cycle guard, in which case the
+	/// result is incomplete and must not be cached.
+	private func localBounds(
+		objectKey: String,
+		cache: inout [String: Bounds?],
+		hitCycle: inout Bool,
+		visited: Set<String> = [],
+		depth: Int = 0
+	) -> Bounds? {
+		if let cached = cache[objectKey] {
+			return cached
+		}
+		// This walks the same graph as `makeNode` and needs the same bound on its recursion. The
+		// result is incomplete when the walk stops early, so it is reported like a cycle.
+		guard depth < ThreeMFLimits.maxObjectDepth else {
+			hitCycle = true
+			return nil
+		}
+		guard !visited.contains(objectKey) else {
+			hitCycle = true
+			return nil
+		}
+		guard let object = objects[objectKey] else {
+			return nil
+		}
+		var visited = visited
+		visited.insert(objectKey)
+
+		var truncated = false
+		var bounds = object.mesh.flatMap { Bounds(vertices: $0.vertices) }
+		for component in object.components {
+			guard let componentBounds = localBounds(
+				objectKey: component.objectKey,
+				cache: &cache,
+				hitCycle: &truncated,
+				visited: visited,
+				depth: depth + 1
+			)?.transformed(by: component.transform) else {
+				continue
+			}
+			bounds = bounds?.union(componentBounds) ?? componentBounds
+		}
+
+		if truncated {
+			hitCycle = true
+		} else {
+			cache[objectKey] = bounds
+		}
+		return bounds
+	}
+
+	private func color(of object: ThreeMFObject) -> NSColor {
+		guard let groupKey = object.propertyGroupKey,
+		      let index = object.propertyIndex,
+		      let colors = propertyGroups[groupKey],
+		      colors.indices.contains(index)
+		else {
+			return ThreeMFModel.defaultColor
+		}
+		return colors[index]
+	}
+
+	/// Converts a mesh to a SceneKit geometry. Vertices are duplicated for every triangle so that
+	/// each face gets its own normal: 3MF meshes share vertices between faces, and averaging their
+	/// normals would make hard edges look rounded.
+	private static func makeGeometry(mesh: ThreeMFMesh, color: NSColor) -> SCNGeometry? {
+		// Coordinates are kept as single precision floats: large models have millions of them, and
+		// SceneKit converts them to floats when rendering anyway
+		var positions = [Float]()
+		var normals = [Float]()
+		positions.reserveCapacity(mesh.triangles.count * 3)
+		normals.reserveCapacity(mesh.triangles.count * 3)
+		var vertexCount = 0
+
+		for index in stride(from: 0, to: mesh.triangles.count, by: 3) {
+			let indices = [
+				Int(mesh.triangles[index]),
+				Int(mesh.triangles[index + 1]),
+				Int(mesh.triangles[index + 2]),
+			]
+			// Skip triangles referencing vertices that don't exist
+			guard indices.allSatisfy({ mesh.vertices.indices.contains($0) }) else {
+				continue
+			}
+
+			let vertices = indices.map { mesh.vertices[$0] }
+			let normal = faceNormal(vertices[0], vertices[1], vertices[2])
+			for vertex in vertices {
+				positions.append(contentsOf: [Float(vertex.x), Float(vertex.y), Float(vertex.z)])
+				normals.append(contentsOf: [Float(normal.x), Float(normal.y), Float(normal.z)])
+			}
+			vertexCount += 3
+		}
+
+		guard vertexCount > 0 else {
+			return nil
+		}
+
+		let element = SCNGeometryElement(
+			indices: [Int32](0 ..< Int32(vertexCount)),
+			primitiveType: .triangles
+		)
+		let geometry = SCNGeometry(
+			sources: [
+				makeSource(components: positions, count: vertexCount, semantic: .vertex),
+				makeSource(components: normals, count: vertexCount, semantic: .normal),
+			],
+			elements: [element]
+		)
+
+		let material = SCNMaterial()
+		material.lightingModel = .physicallyBased
+		material.diffuse.contents = color
+		material.metalness.contents = 0.0
+		material.roughness.contents = 0.55
+		// Meshes with inconsistently oriented triangles are common, so render both sides
+		material.isDoubleSided = true
+		geometry.materials = [material]
+
+		return geometry
+	}
+
+	/// Builds a geometry source from a flat list of three-dimensional vectors.
+	private static func makeSource(
+		components: [Float],
+		count: Int,
+		semantic: SCNGeometrySource.Semantic
+	) -> SCNGeometrySource {
+		let data = components.withUnsafeBufferPointer { Data(buffer: $0) }
+		return SCNGeometrySource(
+			data: data,
+			semantic: semantic,
+			vectorCount: count,
+			usesFloatComponents: true,
+			componentsPerVector: 3,
+			bytesPerComponent: MemoryLayout<Float>.size,
+			dataOffset: 0,
+			dataStride: MemoryLayout<Float>.size * 3
+		)
+	}
+
+	private static func faceNormal(
+		_ first: SCNVector3,
+		_ second: SCNVector3,
+		_ third: SCNVector3
+	) -> SCNVector3 {
+		let edge1 = SCNVector3(second.x - first.x, second.y - first.y, second.z - first.z)
+		let edge2 = SCNVector3(third.x - first.x, third.y - first.y, third.z - first.z)
+		return edge1.cross(edge2).normalized()
+	}
+
+	/// Builds the camera showing the model. It is positioned by `ModelCamera` once the size of the
+	/// view is known.
+	private func makeCamera(bounds: Bounds?) -> ModelCamera {
+		guard let bounds = bounds, bounds.radius > 0 else {
+			return ModelCamera(target: SCNVector3Zero, corners: [], radius: 0)
+		}
+
+		// Convert the bounding box from the model's Z-up system to SceneKit's Y-up system
+		let center = bounds.center
+		return ModelCamera(
+			target: SCNVector3(center.x, center.z, -center.y),
+			corners: bounds.corners.map { SCNVector3($0.x, $0.z, -$0.y) },
+			radius: bounds.radius
+		)
+	}
+
+	/// Adds ambient light, so that the sides facing away from the camera don't turn black. The
+	/// remaining lighting is provided by `SCNView.autoenablesDefaultLighting`.
+	private func addLights(to scene: SCNScene) {
+		let light = SCNLight()
+		light.type = .ambient
+		light.color = NSColor(calibratedWhite: 0.45, alpha: 1)
+
+		let lightNode = SCNNode()
+		lightNode.light = light
+		scene.rootNode.addChildNode(lightNode)
+	}
+}

--- a/QLPlugin/Utils/ThreeMF/ThreeMFParser.swift
+++ b/QLPlugin/Utils/ThreeMF/ThreeMFParser.swift
@@ -1,0 +1,675 @@
+import Cocoa
+import Foundation
+import os.log
+import SceneKit
+import ZIPFoundation
+
+/// Budgets that keep a malformed or hostile 3MF file from exhausting memory or time. Previews are
+/// generated inside a sandboxed extension, so refusing to render a file is always better than
+/// hanging or being killed.
+enum ThreeMFLimits {
+	/// Triangles of the whole file. SceneKit keeps three vertices per triangle in memory, and
+	/// Quick Look previews are expected to be quick.
+	static let maxTriangles = 1_000_000
+	/// Vertices of the whole file, which a file can declare without declaring any triangle. A mesh
+	/// has roughly half as many vertices as triangles, so this is generous.
+	static let maxVertices = 1_500_000
+	/// Decompressed size of a single model part
+	static let maxPartSize = 256_000_000
+	/// Decompressed size of all model parts of a file
+	static let maxTotalSize = 512_000_000
+	/// Model parts of a file (the production extension allows referencing arbitrarily many)
+	static let maxParts = 64
+	/// Nodes of the rendered scene. Objects referencing each other without forming a cycle still
+	/// expand exponentially, so the triangle count of the file doesn't bound this.
+	static let maxNodes = 100_000
+	/// Levels of objects referencing other objects. This bounds the depth of the recursion that
+	/// walks them, which `maxNodes` does not: a chain of objects each holding a single component
+	/// uses one node per level. Real files nest a handful of levels deep.
+	static let maxObjectDepth = 128
+	/// Size of the file itself. The budgets below bound what is read out of the container, but the
+	/// container's own table of contents is read before any of them applies.
+	static let maxFileSize = 200_000_000
+	/// Depth of the element path that is tracked while parsing. Valid 3MF nests a few levels deep;
+	/// this only keeps a deeply nested file from growing the path without bound.
+	static let maxElementDepth = 64
+	/// Files in the container, which are indexed before anything else is read. A 3MF holds a
+	/// handful of them.
+	static let maxEntries = 4096
+	/// Size of the relationships part, which only holds a few references
+	static let maxRelationshipsSize = 1_000_000
+	/// Largest coordinate that can be rendered. Geometry is handed to SceneKit as single precision
+	/// floats, which overflow above ~3.4e38, and the camera divides coordinates by the tangent of
+	/// its field of view. A millionth of that is still far larger than any real model.
+	static let maxCoordinate = 1e12
+}
+
+enum ThreeMFError: Error {
+	case archiveReadError(path: String)
+	case modelNotFoundError(path: String)
+	case parseError(message: String)
+	case emptyModelError
+	case tooLargeError(reason: String)
+}
+
+extension ThreeMFError: LocalizedError {
+	var errorDescription: String? {
+		switch self {
+			case let .archiveReadError(path):
+				return NSLocalizedString("Could not open 3MF file at path \(path)", comment: "")
+			case let .modelNotFoundError(path):
+				return NSLocalizedString(
+					"3MF file at path \(path) does not contain a model",
+					comment: ""
+				)
+			case let .parseError(message):
+				return NSLocalizedString("Could not parse 3MF model: \(message)", comment: "")
+			case .emptyModelError:
+				return NSLocalizedString("3MF model does not contain any geometry", comment: "")
+			case let .tooLargeError(reason):
+				return NSLocalizedString(
+					"3MF model is too large to preview: \(reason)",
+					comment: ""
+				)
+		}
+	}
+}
+
+/// Parses 3MF files. A 3MF file is a ZIP container holding one or more XML model parts, which
+/// describe the objects of the model and their placement on the build platform.
+///
+/// The core specification is implemented, as well as the parts of the material and production
+/// extensions that affect what the preview looks like (object colors and models split across
+/// several parts). Other extensions (e.g. beam lattice) are ignored.
+///
+/// The contents of the file are untrusted: everything that grows with what the file declares is
+/// bounded by `ThreeMFLimits`.
+class ThreeMFParser: NSObject {
+	/// Relationship type pointing to the model part to start parsing at
+	private static let modelRelationshipType =
+		"http://schemas.microsoft.com/3dmanufacturing/2013/01/3dmodel"
+	/// Path of the model part used when the container doesn't declare a relationship
+	private static let defaultModelPath = "3D/3dmodel.model"
+	private static let relationshipsPath = "_rels/.rels"
+
+	private let archive: Archive
+
+	/// Entries of the container, keyed by their normalized lowercased path. Paths inside a 3MF file
+	/// are case-insensitive, and indexing them is what makes looking one up a constant-time
+	/// operation.
+	private var entriesByPath = [String: Entry]()
+
+	// Parsing state
+	private var model = ThreeMFModel()
+	private var currentPartPath = ""
+	private var isRootPart = true
+	private var pendingParts = [String]()
+	private var parsedParts = Set<String>()
+	private var totalPartSize = 0
+	private var vertexCount = 0
+
+	/// Local names of the elements enclosing the one being parsed, the current one last
+	private var elementPath = [String]()
+	private var elementDepth = 0
+	private var currentObjectKey: String?
+	private var currentObject: ThreeMFObject?
+	private var currentMesh: ThreeMFMesh?
+	/// Depth of the `<mesh>` element being read, so that an element of the same name nested inside
+	/// it doesn't end it
+	private var currentMeshDepth: Int?
+	private var currentPropertyGroupKey: String?
+	private var currentPropertyColors = [NSColor]()
+	/// Depth of the property group being read, for the same reason as `currentMeshDepth`
+	private var currentPropertyGroupDepth: Int?
+	private var parseError: ThreeMFError?
+
+	init(fileURL: URL) throws {
+		guard let archive = Archive(url: fileURL, accessMode: .read) else {
+			throw ThreeMFError.archiveReadError(path: fileURL.path)
+		}
+		self.archive = archive
+	}
+
+	/// Indexes the entries of the container. This runs before anything is read, so the number of
+	/// entries has to be bounded here rather than by one of the budgets below.
+	private func buildEntryIndex() throws {
+		var count = 0
+		for entry in archive {
+			count += 1
+			guard count <= ThreeMFLimits.maxEntries else {
+				throw ThreeMFError
+					.tooLargeError(reason: "more than \(ThreeMFLimits.maxEntries) files")
+			}
+			// The first entry wins, like `Archive`'s own lookup does
+			let path = ThreeMFParser.normalize(path: entry.path).lowercased()
+			if entriesByPath[path] == nil {
+				entriesByPath[path] = entry
+			}
+		}
+	}
+
+	/// Parses the model parts of the container and returns their contents.
+	func parse() throws -> ThreeMFModel {
+		try buildEntryIndex()
+		pendingParts = [rootModelPath()]
+
+		while let requestedPath = pendingParts.popLast() {
+			guard let entry = entry(at: requestedPath) else {
+				// Parts referenced by a malformed file may not exist. Only the root part is
+				// required.
+				if isRootPart {
+					throw ThreeMFError.modelNotFoundError(path: requestedPath)
+				}
+				os_log(
+					"Skipping missing 3MF model part %{public}s",
+					log: Log.parse,
+					type: .error,
+					requestedPath
+				)
+				continue
+			}
+
+			// Parts are tracked by the path of the entry they resolve to, so that referencing the
+			// same part under different spellings doesn't parse it several times
+			guard !parsedParts.contains(entry.path) else {
+				continue
+			}
+			guard parsedParts.count < ThreeMFLimits.maxParts else {
+				throw ThreeMFError
+					.tooLargeError(reason: "more than \(ThreeMFLimits.maxParts) model parts")
+			}
+			parsedParts.insert(entry.path)
+
+			let data: Data
+			do {
+				data = try self.data(of: entry)
+			} catch {
+				// A part that is too large is not worth skipping over: the file is out of budget
+				if isRootPart || error is ThreeMFError {
+					throw error
+				}
+				os_log(
+					"Skipping unreadable 3MF model part %{public}s: %{public}s",
+					log: Log.parse,
+					type: .error,
+					entry.path,
+					error.localizedDescription
+				)
+				continue
+			}
+
+			try parsePart(data: data, path: entry.path)
+			isRootPart = false
+		}
+
+		guard model.triangleCount > 0 else {
+			throw ThreeMFError.emptyModelError
+		}
+
+		// Some files (mostly exported by CAD software) don't declare a build platform. Showing
+		// their objects is more useful than showing an empty preview. An explicitly empty `<build>`
+		// is indistinguishable from a missing one here, which is an acceptable trade-off: a file
+		// with objects but nothing on the platform is not worth an empty preview either.
+		if model.buildItems.isEmpty {
+			model.buildItems = topLevelObjectKeys().map {
+				ThreeMFBuildItem(objectKey: $0, transform: SCNMatrix4Identity)
+			}
+		}
+
+		return model
+	}
+
+	/// Keys of the objects that aren't part of another object, sorted to keep the preview stable
+	/// across runs.
+	private func topLevelObjectKeys() -> [String] {
+		let componentKeys = Set(model.objects.values.flatMap { $0.components.map(\.objectKey) })
+		return model.objects.keys.filter { !componentKeys.contains($0) }.sorted()
+	}
+
+	private func parsePart(data: Data, path: String) throws {
+		currentPartPath = path
+		elementPath = []
+		elementDepth = 0
+		currentObjectKey = nil
+		currentObject = nil
+		currentMesh = nil
+		currentMeshDepth = nil
+		currentPropertyGroupKey = nil
+		currentPropertyColors = []
+		currentPropertyGroupDepth = nil
+
+		let parser = XMLParser(data: data)
+		parser.delegate = self
+		let success = parser.parse()
+
+		// Budgets are global, so a part exceeding one aborts the whole preview
+		if let parseError = parseError {
+			throw parseError
+		}
+		if !success, isRootPart {
+			throw ThreeMFError.parseError(
+				message: parser.parserError?.localizedDescription ?? "unknown error"
+			)
+		}
+	}
+
+	// MARK: - Archive
+
+	/// Returns the path of the model part referenced by the container's relationships, falling back
+	/// to the conventional path.
+	private func rootModelPath() -> String {
+		guard let entry = entry(at: ThreeMFParser.relationshipsPath),
+		      let data = try? data(of: entry, limit: ThreeMFLimits.maxRelationshipsSize),
+		      let path = relationshipTarget(in: data)
+		else {
+			return ThreeMFParser.defaultModelPath
+		}
+		return ThreeMFParser.normalize(path: path)
+	}
+
+	private func relationshipTarget(in data: Data) -> String? {
+		RelationshipsParser.target(of: ThreeMFParser.modelRelationshipType, in: data)
+	}
+
+	/// Reads an entry of the container into memory. The size the entry declares is metadata written
+	/// by whoever created the file, so the data that is actually read has to be counted as well.
+	private func data(of entry: Entry, limit: Int = ThreeMFLimits.maxPartSize) throws -> Data {
+		guard entry.uncompressedSize <= UInt64(limit) else {
+			throw ThreeMFError.tooLargeError(reason: "model part \(entry.path) is too large")
+		}
+		var budget = min(limit, ThreeMFLimits.maxTotalSize - totalPartSize)
+		// An entry that decompresses to more than it says it will is malformed, so there is no
+		// reason to read the rest of it
+		let declaredSize = Int(entry.uncompressedSize)
+		if declaredSize > 0 {
+			budget = min(budget, declaredSize)
+		}
+
+		var data = Data()
+		// The reservation follows what the file declares, so it is only a starting point
+		data.reserveCapacity(min(budget, 8_000_000))
+		// Checking the CRC32 of the entry means reading it twice, which is unnecessary for a
+		// preview
+		_ = try archive.extract(entry, skipCRC32: true) { chunk in
+			guard data.count + chunk.count <= budget else {
+				throw ThreeMFError.tooLargeError(reason: "model part \(entry.path) is too large")
+			}
+			data.append(chunk)
+		}
+
+		totalPartSize += data.count
+		return data
+	}
+
+	private func entry(at path: String) -> Entry? {
+		entriesByPath[ThreeMFParser.normalize(path: path).lowercased()]
+	}
+
+	/// Paths inside a 3MF file are absolute, while paths of ZIP entries are not.
+	private static func normalize(path: String) -> String {
+		path.hasPrefix("/") ? String(path.dropFirst()) : path
+	}
+
+	/// Returns the path of the entry a reference resolves to, so that resources are keyed by the
+	/// part that actually holds them however the reference is spelled.
+	private func canonicalPath(of path: String?) -> String {
+		guard let path = path else {
+			return currentPartPath
+		}
+		let normalized = ThreeMFParser.normalize(path: path)
+		return entry(at: normalized)?.path ?? normalized
+	}
+
+	// MARK: - Parsing helpers
+
+	/// Key uniquely identifying a resource. IDs are only unique within the model part that declares
+	/// them, so the part path is part of the key.
+	private func key(path: String?, id: String) -> String {
+		"\(canonicalPath(of: path))#\(id)"
+	}
+
+	/// Returns an attribute of an element, ignoring the namespace prefix it may carry (e.g. the
+	/// `path` attribute of the production extension).
+	private static func attribute(
+		_ name: String,
+		of attributes: [String: String]
+	) -> String? {
+		if let value = attributes[name] {
+			return value
+		}
+		// The prefix is chosen by the file, and several extensions may define an attribute with the
+		// same local name, so the match is made deterministic rather than left to dictionary order
+		let suffix = ":" + name
+		return attributes.filter { $0.key.hasSuffix(suffix) }.min { $0.key < $1.key }?.value
+	}
+
+	/// Parses the 12 values of a 3MF transform. They are the first three columns of a 4x4 matrix in
+	/// row-major order, which is the layout SceneKit uses as well.
+	private static func transform(from string: String?) -> SCNMatrix4 {
+		guard let values = string?
+			.split(whereSeparator: { $0 == " " || $0 == "\t" || $0 == "\n" || $0 == "\r" })
+			.compactMap({ Double($0) }),
+			values.count == 12,
+			values.allSatisfy({ isRenderable($0) })
+		else {
+			return SCNMatrix4Identity
+		}
+
+		var matrix = SCNMatrix4Identity
+		matrix.m11 = CGFloat(values[0])
+		matrix.m12 = CGFloat(values[1])
+		matrix.m13 = CGFloat(values[2])
+		matrix.m21 = CGFloat(values[3])
+		matrix.m22 = CGFloat(values[4])
+		matrix.m23 = CGFloat(values[5])
+		matrix.m31 = CGFloat(values[6])
+		matrix.m32 = CGFloat(values[7])
+		matrix.m33 = CGFloat(values[8])
+		matrix.m41 = CGFloat(values[9])
+		matrix.m42 = CGFloat(values[10])
+		matrix.m43 = CGFloat(values[11])
+		return matrix
+	}
+
+	/// Returns a coordinate that can be rendered. Values that are out of range reach the bounding
+	/// box, the camera and finally Metal, where they turn the whole preview blank. Checking for
+	/// infinity is not enough: geometry is stored as single precision floats, and the camera
+	/// divides coordinates by the tangent of its field of view.
+	private static func coordinate(_ value: Double) -> CGFloat {
+		isRenderable(value) ? CGFloat(value) : 0
+	}
+
+	private static func isRenderable(_ value: Double) -> Bool {
+		value.isFinite && abs(value) <= ThreeMFLimits.maxCoordinate
+	}
+
+	/// Parses a color in `#RRGGBB` or `#RRGGBBAA` notation.
+	private static func color(from string: String?) -> NSColor? {
+		guard var hex = string, hex.hasPrefix("#") else {
+			return nil
+		}
+		hex.removeFirst()
+		guard hex.count == 6 || hex.count == 8, let value = UInt32(hex, radix: 16) else {
+			return nil
+		}
+
+		let hasAlpha = hex.count == 8
+		let red = (value >> (hasAlpha ? 24 : 16)) & 0xFF
+		let green = (value >> (hasAlpha ? 16 : 8)) & 0xFF
+		let blue = (value >> (hasAlpha ? 8 : 0)) & 0xFF
+		let alpha = hasAlpha ? value & 0xFF : 255
+
+		return NSColor(
+			calibratedRed: CGFloat(red) / 255,
+			green: CGFloat(green) / 255,
+			blue: CGFloat(blue) / 255,
+			alpha: CGFloat(alpha) / 255
+		)
+	}
+
+	/// Queues a model part referenced by the production extension for parsing.
+	private func enqueue(partPath: String?) {
+		guard let partPath = partPath else {
+			return
+		}
+		let path = canonicalPath(of: partPath)
+		guard path != currentPartPath, !parsedParts.contains(path) else {
+			return
+		}
+		// Referencing more parts than can be parsed only wastes memory
+		guard pendingParts.count < ThreeMFLimits.maxParts, !pendingParts.contains(path) else {
+			return
+		}
+		pendingParts.append(path)
+	}
+
+	/// Whether the element being parsed is enclosed in the provided elements, innermost first.
+	/// Elements of unsupported extensions (e.g. beam lattice) reuse the names of the core
+	/// specification, so their contents must not be taken for the object's mesh.
+	private func isEnclosed(in ancestors: String...) -> Bool {
+		// Past the tracked depth the path no longer ends with the current element, so it cannot be
+		// used to tell where the element sits. Valid 3MF never nests that deep.
+		guard elementDepth <= ThreeMFLimits.maxElementDepth,
+		      elementPath.count > ancestors.count
+		else {
+			return false
+		}
+		// The current element is last, so its ancestors are the elements before it
+		let enclosing = elementPath.dropLast().suffix(ancestors.count).reversed()
+		return enclosing.elementsEqual(ancestors)
+	}
+
+	/// Records that a limit was reached and stops parsing.
+	private func abort(_ parser: XMLParser, reason: String) {
+		parseError = .tooLargeError(reason: reason)
+		parser.abortParsing()
+	}
+}
+
+// MARK: - XMLParserDelegate
+
+extension ThreeMFParser: XMLParserDelegate {
+	func parser(
+		_ parser: XMLParser,
+		didStartElement elementName: String,
+		namespaceURI _: String?,
+		qualifiedName _: String?,
+		attributes: [String: String] = [:]
+	) {
+		let localName = ThreeMFParser.localName(of: elementName)
+		elementDepth += 1
+		if elementDepth <= ThreeMFLimits.maxElementDepth {
+			elementPath.append(localName)
+		}
+
+		switch localName {
+			case "model":
+				if isRootPart, let unit = ThreeMFParser.attribute("unit", of: attributes) {
+					model.unit = ThreeMFUnit(rawValue: unit) ?? .millimeter
+				}
+			case "object":
+				guard let id = ThreeMFParser.attribute("id", of: attributes) else {
+					break
+				}
+				currentObjectKey = key(path: nil, id: id)
+				var object = ThreeMFObject()
+				let groupID = ThreeMFParser.attribute("pid", of: attributes)
+				let index = ThreeMFParser.attribute("pindex", of: attributes).flatMap(Int.init)
+				if let groupID = groupID, let index = index {
+					object.propertyGroupKey = key(path: nil, id: groupID)
+					object.propertyIndex = index
+				}
+				currentObject = object
+			case "mesh":
+				guard isEnclosed(in: "object") else {
+					break
+				}
+				currentMesh = ThreeMFMesh()
+				currentMeshDepth = elementDepth
+			case "vertex":
+				// The enclosing elements have the right names, but they also have to be the ones
+				// that were accepted: a `<mesh>` nested inside the open one is ignored, and so are
+				// its vertices
+				guard elementDepth == (currentMeshDepth ?? .min) + 2,
+				      isEnclosed(in: "vertices", "mesh"),
+				      let x = ThreeMFParser.attribute("x", of: attributes).flatMap(Double.init),
+				      let y = ThreeMFParser.attribute("y", of: attributes).flatMap(Double.init),
+				      let z = ThreeMFParser.attribute("z", of: attributes).flatMap(Double.init)
+				else {
+					break
+				}
+				vertexCount += 1
+				guard vertexCount <= ThreeMFLimits.maxVertices else {
+					abort(parser, reason: "more than \(ThreeMFLimits.maxVertices) vertices")
+					break
+				}
+				// Triangles refer to vertices by index, so a vertex is never dropped: an
+				// out-of-range coordinate is replaced instead, which keeps the damage local
+				currentMesh?.vertices.append(SCNVector3(
+					ThreeMFParser.coordinate(x),
+					ThreeMFParser.coordinate(y),
+					ThreeMFParser.coordinate(z)
+				))
+			case "triangle":
+				guard elementDepth == (currentMeshDepth ?? .min) + 2,
+				      isEnclosed(in: "triangles", "mesh"),
+				      let v1 = ThreeMFParser.attribute("v1", of: attributes).flatMap(Int32.init),
+				      let v2 = ThreeMFParser.attribute("v2", of: attributes).flatMap(Int32.init),
+				      let v3 = ThreeMFParser.attribute("v3", of: attributes).flatMap(Int32.init)
+				else {
+					break
+				}
+				model.triangleCount += 1
+				guard model.triangleCount <= ThreeMFLimits.maxTriangles else {
+					abort(parser, reason: "more than \(ThreeMFLimits.maxTriangles) triangles")
+					break
+				}
+				currentMesh?.triangles.append(contentsOf: [v1, v2, v3])
+			case "component":
+				guard isEnclosed(in: "components", "object"),
+				      let id = ThreeMFParser.attribute("objectid", of: attributes)
+				else {
+					break
+				}
+				let path = ThreeMFParser.attribute("path", of: attributes)
+				enqueue(partPath: path)
+				currentObject?.components.append(ThreeMFComponent(
+					objectKey: key(path: path, id: id),
+					transform: ThreeMFParser
+						.transform(from: ThreeMFParser.attribute("transform", of: attributes))
+				))
+			case "item":
+				guard isEnclosed(in: "build"),
+				      let id = ThreeMFParser.attribute("objectid", of: attributes)
+				else {
+					break
+				}
+				let path = ThreeMFParser.attribute("path", of: attributes)
+				enqueue(partPath: path)
+				model.buildItems.append(ThreeMFBuildItem(
+					objectKey: key(path: path, id: id),
+					transform: ThreeMFParser
+						.transform(from: ThreeMFParser.attribute("transform", of: attributes))
+				))
+			case "basematerials", "colorgroup":
+				guard isEnclosed(in: "resources"),
+				      let id = ThreeMFParser.attribute("id", of: attributes)
+				else {
+					break
+				}
+				currentPropertyGroupKey = key(path: nil, id: id)
+				currentPropertyColors = []
+				currentPropertyGroupDepth = elementDepth
+			case "base":
+				guard elementDepth == (currentPropertyGroupDepth ?? .min) + 1,
+				      isEnclosed(in: "basematerials")
+				else {
+					break
+				}
+				currentPropertyColors.append(
+					ThreeMFParser
+						.color(from: ThreeMFParser.attribute("displaycolor", of: attributes))
+						?? ThreeMFModel.defaultColor
+				)
+			case "color":
+				guard elementDepth == (currentPropertyGroupDepth ?? .min) + 1,
+				      isEnclosed(in: "colorgroup")
+				else {
+					break
+				}
+				currentPropertyColors.append(
+					ThreeMFParser.color(from: ThreeMFParser.attribute("color", of: attributes))
+						?? ThreeMFModel.defaultColor
+				)
+			default:
+				break
+		}
+	}
+
+	func parser(
+		_: XMLParser,
+		didEndElement elementName: String,
+		namespaceURI _: String?,
+		qualifiedName _: String?
+	) {
+		switch ThreeMFParser.localName(of: elementName) {
+			// The end of an element only ends what its start began: an element of the same name
+			// nested inside it (which an unsupported extension may declare) must not truncate it
+			case "mesh":
+				if elementDepth == currentMeshDepth {
+					currentObject?.mesh = currentMesh
+					currentMesh = nil
+					currentMeshDepth = nil
+				}
+			case "object":
+				if let key = currentObjectKey, let object = currentObject {
+					model.objects[key] = object
+				}
+				currentObjectKey = nil
+				currentObject = nil
+				currentMesh = nil
+				currentMeshDepth = nil
+			case "basematerials", "colorgroup":
+				if elementDepth == currentPropertyGroupDepth {
+					if let key = currentPropertyGroupKey {
+						model.propertyGroups[key] = currentPropertyColors
+					}
+					currentPropertyGroupKey = nil
+					currentPropertyColors = []
+					currentPropertyGroupDepth = nil
+				}
+			default:
+				break
+		}
+
+		if elementDepth <= ThreeMFLimits.maxElementDepth, !elementPath.isEmpty {
+			elementPath.removeLast()
+		}
+		elementDepth -= 1
+	}
+
+	/// Returns the name of an element without its namespace prefix.
+	private static func localName(of elementName: String) -> String {
+		guard let separatorIndex = elementName.lastIndex(of: ":") else {
+			return elementName
+		}
+		return String(elementName[elementName.index(after: separatorIndex)...])
+	}
+}
+
+// MARK: - Relationships
+
+/// Parses the relationships part of a 3MF container, which points to the model part to start at.
+private class RelationshipsParser: NSObject, XMLParserDelegate {
+	private let type: String
+	private var target: String?
+
+	private init(type: String) {
+		self.type = type
+	}
+
+	/// Returns the target of the first relationship with the provided type.
+	static func target(of type: String, in data: Data) -> String? {
+		let delegate = RelationshipsParser(type: type)
+		let parser = XMLParser(data: data)
+		parser.delegate = delegate
+		parser.parse()
+		return delegate.target
+	}
+
+	func parser(
+		_: XMLParser,
+		didStartElement elementName: String,
+		namespaceURI _: String?,
+		qualifiedName _: String?,
+		attributes: [String: String] = [:]
+	) {
+		guard elementName.hasSuffix("Relationship"),
+		      target == nil,
+		      attributes["Type"] == type
+		else {
+			return
+		}
+		target = attributes["Target"]
+	}
+}

--- a/QLPlugin/Views/PreviewVCFactory.swift
+++ b/QLPlugin/Views/PreviewVCFactory.swift
@@ -5,6 +5,8 @@ import Foundation
 class PreviewVCFactory {
 	static func getPreviewInitializer(fileURL: URL) -> Preview.Type? {
 		switch fileURL.pathExtension.lowercased() {
+			case "3mf":
+				return ThreeMFPreview.self
 			case "gz":
 				// `gzip` is only supported for tarballs
 				return fileURL.path.hasSuffix(".tar.gz") ? TARPreview.self : nil

--- a/QLPlugin/Views/PreviewVCs/ModelCamera.swift
+++ b/QLPlugin/Views/PreviewVCs/ModelCamera.swift
@@ -1,0 +1,85 @@
+import Cocoa
+import SceneKit
+
+/// Camera looking at a model from a three-quarter view. The distance to the model depends on the
+/// aspect ratio of the view it is rendered in, so it is only known once the view has been laid out.
+class ModelCamera {
+	/// Vertical field of view, in degrees
+	private static let fieldOfView: CGFloat = 40
+	/// Direction the model is looked at from
+	private static let direction = SCNVector3(0.55, 0.45, 1)
+	/// Empty space kept around the model
+	private static let margin: CGFloat = 1.05
+
+	let node: SCNNode
+
+	/// Point the camera looks at
+	private let target: SCNVector3
+	/// Corners of the model's bounding box, which all have to be visible
+	private let corners: [SCNVector3]
+	private let radius: CGFloat
+
+	init(target: SCNVector3, corners: [SCNVector3], radius: CGFloat) {
+		self.target = target
+		self.corners = corners
+		self.radius = radius
+
+		let camera = SCNCamera()
+		camera.fieldOfView = ModelCamera.fieldOfView
+		camera.projectionDirection = .vertical
+		// The user can zoom and pan freely, so the visible depth range cannot be computed once
+		camera.automaticallyAdjustsZRange = true
+
+		node = SCNNode()
+		node.camera = camera
+		node.position = SCNVector3(target.x, target.y, target.z + max(radius * 3, 1))
+		node.look(at: target)
+	}
+
+	/// Moves the camera to the distance at which the whole model is visible.
+	func frame(aspectRatio: CGFloat) {
+		guard radius > 0, aspectRatio > 0 else {
+			return
+		}
+
+		let direction = ModelCamera.direction.normalized()
+		let distance = self.distance(aspectRatio: aspectRatio, direction: direction)
+
+		node.position = SCNVector3(
+			target.x + direction.x * distance,
+			target.y + direction.y * distance,
+			target.z + direction.z * distance
+		)
+		node.look(at: target)
+	}
+
+	/// Returns the smallest distance from the model's center at which every corner of its bounding
+	/// box is inside the field of view.
+	private func distance(aspectRatio: CGFloat, direction: SCNVector3) -> CGFloat {
+		// Basis of the camera, which looks at the target from `direction`
+		let forward = SCNVector3(-direction.x, -direction.y, -direction.z)
+		let right = forward.cross(SCNVector3(0, 1, 0)).normalized()
+		let up = right.cross(forward).normalized()
+
+		let verticalTangent = tan(ModelCamera.fieldOfView * .pi / 360)
+		let horizontalTangent = verticalTangent * aspectRatio
+
+		var distance: CGFloat = 0
+		for corner in corners {
+			let offset = SCNVector3(
+				corner.x - target.x,
+				corner.y - target.y,
+				corner.z - target.z
+			)
+			// Distance at which the corner reaches the edge of the field of view. Corners in front
+			// of the target (positive depth) need less distance than corners behind it.
+			let depth = offset.dot(forward)
+			distance = max(
+				distance,
+				abs(offset.dot(right)) / horizontalTangent - depth,
+				abs(offset.dot(up)) / verticalTangent - depth
+			)
+		}
+		return distance * ModelCamera.margin
+	}
+}

--- a/QLPlugin/Views/PreviewVCs/ModelPreviewVC.swift
+++ b/QLPlugin/Views/PreviewVCs/ModelPreviewVC.swift
@@ -1,0 +1,114 @@
+import Cocoa
+import SceneKit
+
+/// View controller for previewing 3D models. The model can be rotated, panned and zoomed.
+class ModelPreviewVC: NSViewController, PreviewVC {
+	private static let labelPadding: CGFloat = 10
+
+	private let scene: SCNScene
+	private let camera: ModelCamera
+	private let labelText: String?
+
+	/// The camera is only framed once, so that resizing the preview doesn't undo the rotating and
+	/// zooming the user may have done
+	private var hasFramedCamera = false
+
+	required convenience init(scene: SCNScene, camera: ModelCamera, labelText: String?) {
+		self.init(
+			nibName: nil,
+			bundle: nil,
+			scene: scene,
+			camera: camera,
+			labelText: labelText
+		)
+	}
+
+	init(
+		nibName nibNameOrNil: NSNib.Name?,
+		bundle nibBundleOrNil: Bundle?,
+		scene: SCNScene,
+		camera: ModelCamera,
+		labelText: String?
+	) {
+		self.scene = scene
+		self.camera = camera
+		self.labelText = labelText
+		super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+	}
+
+	@available(*, unavailable)
+	required init?(coder _: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+
+	override func loadView() {
+		// The view is resized by whoever displays it, but starting from a non-empty size avoids
+		// laying out the preview at zero size
+		view = NSView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
+	}
+
+	override func viewDidLoad() {
+		super.viewDidLoad()
+		setUpView()
+	}
+
+	/// The camera can only be positioned once the size of the view is known, because how far the
+	/// model has to be to fit the view depends on the view's aspect ratio.
+	override func viewDidLayout() {
+		super.viewDidLayout()
+
+		guard !hasFramedCamera, view.bounds.height > 0 else {
+			return
+		}
+		camera.frame(aspectRatio: view.bounds.width / view.bounds.height)
+		hasFramedCamera = true
+	}
+
+	private func setUpView() {
+		let sceneView = SCNView()
+		sceneView.scene = scene
+		sceneView.pointOfView = camera.node
+		sceneView.allowsCameraControl = true
+		sceneView.autoenablesDefaultLighting = true
+		sceneView.antialiasingMode = .multisampling4X
+		// Let the preview's background show through, so it matches the system appearance
+		sceneView.backgroundColor = .clear
+		sceneView.translatesAutoresizingMaskIntoConstraints = false
+		view.addSubview(sceneView)
+
+		NSLayoutConstraint.activate([
+			sceneView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+			sceneView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+			sceneView.topAnchor.constraint(equalTo: view.topAnchor),
+			sceneView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+		])
+
+		guard let labelText = labelText else {
+			return
+		}
+
+		let label = NSTextField(labelWithString: labelText)
+		label.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+		label.textColor = .secondaryLabelColor
+		label.lineBreakMode = .byTruncatingTail
+		label.translatesAutoresizingMaskIntoConstraints = false
+		view.addSubview(label)
+
+		NSLayoutConstraint.activate([
+			label.leadingAnchor.constraint(
+				equalTo: view.leadingAnchor,
+				constant: ModelPreviewVC.labelPadding
+			),
+			// The label is built from the model's own measurements, so it is kept inside the view
+			// however long they turn out to be
+			label.trailingAnchor.constraint(
+				lessThanOrEqualTo: view.trailingAnchor,
+				constant: -ModelPreviewVC.labelPadding
+			),
+			label.bottomAnchor.constraint(
+				equalTo: view.bottomAnchor,
+				constant: -ModelPreviewVC.labelPadding
+			),
+		])
+	}
+}

--- a/QLPlugin/Views/Previews/ThreeMFPreview.swift
+++ b/QLPlugin/Views/Previews/ThreeMFPreview.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+class ThreeMFPreview: Preview {
+	private let dimensionFormatter = NumberFormatter()
+	private let triangleFormatter = NumberFormatter()
+
+	required init() {
+		dimensionFormatter.numberStyle = .decimal
+		dimensionFormatter.maximumFractionDigits = 1
+		triangleFormatter.numberStyle = .decimal
+	}
+
+	func createPreviewVC(file: File) throws -> PreviewVC {
+		// 3MF files are exempt from the size limit that applies to other files, because a small
+		// container can hold a large model. It still needs a limit of its own: the container's
+		// table of contents is read before any of the parser's budgets applies.
+		guard file.size <= ThreeMFLimits.maxFileSize else {
+			let limit = ByteCountFormatter().string(for: ThreeMFLimits.maxFileSize) ?? "the limit"
+			throw ThreeMFError.tooLargeError(reason: "the file is larger than \(limit)")
+		}
+
+		let parser = try ThreeMFParser(fileURL: file.url)
+		let model = try parser.parse()
+		let modelScene = try model.buildScene()
+
+		return ModelPreviewVC(
+			scene: modelScene.scene,
+			camera: modelScene.camera,
+			labelText: buildLabel(scene: modelScene)
+		)
+	}
+
+	/// Builds a label with the model's dimensions and triangle count, e.g.
+	/// "45 × 30 × 12.5 mm — 12,480 triangles".
+	private func buildLabel(scene: ThreeMFScene) -> String {
+		let dimensions = [scene.dimensions.x, scene.dimensions.y, scene.dimensions.z]
+			.map { dimensionFormatter.string(for: $0) ?? "--" }
+			.joined(separator: " × ")
+		let triangles = triangleFormatter.string(for: scene.triangleCount) ?? "--"
+		let unit = scene.triangleCount == 1 ? "triangle" : "triangles"
+
+		return "\(dimensions) mm — \(triangles) \(unit)"
+	}
+}

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Alternatively, you can install Glance directly. The installation is slightly com
 
   <p><img src="./AppStore/Assets/Screenshots/ScreenshotTSV.png" alt="" width="600"></p>
 
+- **3D model** (rendered using SceneKit, can be rotated and zoomed): `.3mf`
+
 ## FAQ
 
 **There are existing Quick Look apps for some of the supported file types. Why create another one?**


### PR DESCRIPTION
Hi @chamburr

This PR adds preview support for .3mf files, the format most 3D printing slicers export. The model is rendered with native SceneKit and can be rotated and zoomed.
It renders the same way as the native STL viewer.

3mf is a container opened as a ZIP, and the model parts are XML parsed with XMLParser.
As some models are quite big, I used the File.archiveExtensions to move the file size limit from 10Mb to 200Mb.

Tested with Bambu Studio and FreeCAD exports, and with deliberately broken files.